### PR TITLE
Add extra Pokemon forms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"@aws-sdk/client-sqs": "^3.485.0",
 				"@octokit/rest": "^20.0.2",
+				"dotenv": "^16.4.1",
 				"pocketbase": "^0.20.1"
 			},
 			"devDependencies": {
@@ -2259,6 +2260,17 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/dotenv": {
+			"version": "16.4.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.1.tgz",
+			"integrity": "sha512-CjA3y+Dr3FyFDOAMnxZEGtnW9KBR2M0JvvUtXNW+dYJL5ROWxP9DUHCwgFqpMk0OXCc0ljhaNTr2w/kutYIcHQ==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/motdotla/dotenv?sponsor=1"
 			}
 		},
 		"node_modules/duplexer2": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 	"dependencies": {
 		"@aws-sdk/client-sqs": "^3.485.0",
 		"@octokit/rest": "^20.0.2",
+		"dotenv": "^16.4.1",
 		"pocketbase": "^0.20.1"
 	},
 	"devDependencies": {

--- a/redeploy.js
+++ b/redeploy.js
@@ -66,6 +66,7 @@ const pokemonDbToJson = async (pb) => {
 		return {
 			id: entry.national_dex,
 			generation: entry.generation,
+			redirect: entry.redirect,
 			names: [
 				{
 					en: entry.en,

--- a/redeploy.js
+++ b/redeploy.js
@@ -9,6 +9,15 @@ const moveFileName = "/moves.json";
 const octokit = new Octokit({ auth: process.env.GITHUB_PAT });
 
 export async function handler(event, context) {
+	try {
+		await main();
+	} catch (err) {
+		console.log(err);
+	}
+	return;
+}
+
+const main = async () => {
 	if (
 		!checkEnvVars([
 			"POCKETBASE_URL",
@@ -49,7 +58,7 @@ export async function handler(event, context) {
 	} catch (err) {
 		console.error(`Moves - Error ${err}`);
 	}
-}
+};
 
 const getExistingFile = async (filename) => {
 	const gitPokemonRequest = await fetch(

--- a/supervisor.js
+++ b/supervisor.js
@@ -3,6 +3,15 @@ import { checkEnvVars } from "./utils.js";
 import { getAuthedPb } from "./pocketbase.js";
 
 export async function handler(event, context) {
+	try {
+		await main();
+	} catch (err) {
+		console.log(err);
+	}
+	return;
+}
+
+const main = async () => {
 	if (
 		!checkEnvVars([
 			"POCKETBASE_URL",
@@ -71,7 +80,7 @@ export async function handler(event, context) {
 	await Promise.all(allQueueMessages);
 
 	// Should expand this to cover missing name entries as well
-}
+};
 
 async function findLastPokemon(pb) {
 	console.log("Getting last PB Pokemon entry");

--- a/supervisor.js
+++ b/supervisor.js
@@ -53,7 +53,7 @@ export async function handler(event, context) {
 		);
 	}
 
-	for (let i = lastMonDbEntry; i < lastAPIMonExtraEntry; i++) {
+	for (let i = lastMonDbExtraEntry; i < lastAPIMonExtraEntry; i++) {
 		allQueueMessages.push(
 			sendSQSMessage(client, {
 				pokemonExtra: i + 1,

--- a/supervisor.js
+++ b/supervisor.js
@@ -164,7 +164,6 @@ async function findLastMove(pb) {
 
 async function sendSQSMessage(client, message) {
 	try {
-		console.log("Adding", message, "to SQS");
 		const command = new SendMessageCommand({
 			QueueUrl: process.env.QUEUE_URL,
 			MessageBody: JSON.stringify(message),

--- a/utils.js
+++ b/utils.js
@@ -1,3 +1,6 @@
+import dotenv from "dotenv";
+dotenv.config();
+
 export function checkEnvVars(vars) {
 	vars.forEach((envVar) => {
 		if (!process.env[envVar]) {

--- a/worker.js
+++ b/worker.js
@@ -39,11 +39,16 @@ export async function handler(event, context) {
 		return;
 	}
 
-	await Promise.all([
-		processPokemon(pb, pokemonIds),
-		processMove(pb, moveIds),
-		processExtraPokemon(pb, extraPokemonIds),
-	]);
+	try {
+		await Promise.all([
+			processPokemon(pb, pokemonIds),
+			processMove(pb, moveIds),
+			processExtraPokemon(pb, extraPokemonIds),
+		]);
+	} catch (err) {
+		console.log(err);
+	}
+	return;
 }
 
 async function processPokemon(pb, ids) {

--- a/worker.js
+++ b/worker.js
@@ -26,7 +26,9 @@ export async function handler(event, context) {
 	const extraPokemonIds = event.Records.map((message) => {
 		const parsedBody = JSON.parse(message.body);
 		return parsedBody.pokemonExtra;
-	}).filter((a) => a);
+	})
+		.filter((a) => a)
+		.filter((a) => a > 10000);
 
 	const moveIds = event.Records.map((message) => {
 		const parsedBody = JSON.parse(message.body);

--- a/worker.js
+++ b/worker.js
@@ -23,19 +23,32 @@ export async function handler(event, context) {
 		return parsedBody.pokemonEntry;
 	}).filter((a) => a);
 
+	const extraPokemonIds = event.Records.map((message) => {
+		const parsedBody = JSON.parse(message.body);
+		return parsedBody.pokemonExtra;
+	}).filter((a) => a);
+
 	const moveIds = event.Records.map((message) => {
 		const parsedBody = JSON.parse(message.body);
 		return parsedBody.moveEntry;
-	});
+	}).filter((a) => a);
 
-	if (!pokemonIds && !moveIds) {
+	if (!pokemonIds && !moveIds && !extraPokemonIds) {
 		return;
 	}
 
-	await Promise.all([processPokemon(pb, pokemonIds), processMove(pb, moveIds)]);
+	await Promise.all([
+		processPokemon(pb, pokemonIds),
+		processMove(pb, moveIds),
+		processExtraPokemon(pb, extraPokemonIds),
+	]);
 }
 
 async function processPokemon(pb, ids) {
+	if (ids.length === 0) {
+		console.log(`Skipping Pokemon`);
+		return;
+	}
 	console.log(`Processing Pokemon - ${JSON.stringify(ids)}`);
 	const pokemonApiResponses = await Promise.all(
 		ids.map((id) => {
@@ -195,7 +208,187 @@ async function processPokemon(pb, ids) {
 	}
 }
 
+async function processExtraPokemon(pb, ids) {
+	if (ids.length === 0) {
+		console.log(`Skipping Extra Pokemon`);
+		return;
+	}
+	console.log(`Processing Extra Pokemon - ${JSON.stringify(ids)}`);
+	const pokemonApiResponses = await Promise.all(
+		ids.map((id) => {
+			return fetch(`https://pokeapi.co/api/v2/pokemon/${id}`, {
+				headers: { "Accept-Encoding": "gzip,deflate,compress" },
+			});
+		})
+	).catch((err) => {
+		console.log(
+			`Error(s) occurred while fetching Extra Pokemon API responses: ${err}`
+		);
+	});
+	console.log(`Extra Pokemon - Received API Responses`);
+
+	const pokemonBodies = await Promise.all(
+		pokemonApiResponses.map((response) => {
+			return response.json();
+		})
+	).catch((err) => {
+		console.log(
+			`Error(s) occurred while parsing Extra Pokemon API responses: ${err}`
+		);
+	});
+
+	const pokemonFormResponses = await Promise.all(
+		pokemonBodies.map(async (body) => {
+			const defaultForm = body.forms[0].url;
+			return fetch(defaultForm, {
+				headers: { "Accept-Encoding": "gzip,deflate,compress" },
+			}).then((res) => {
+				return res.json();
+			});
+		})
+	).catch((err) => {
+		console.log(
+			`Error(s) occurred while fetching Extra Pokemon Form API responses: ${err}`
+		);
+	});
+
+	console.log(`Extra Pokemon - Parsed API responses`);
+
+	const pbData = pokemonFormResponses.map((body) => {
+		return {
+			national_dex: body.id,
+			en: body.names.find((entry) => {
+				return entry.language.name === "en";
+			})?.name,
+			de: body.names.find((entry) => {
+				return entry.language.name === "de";
+			})?.name,
+			es: body.names.find((entry) => {
+				return entry.language.name === "es";
+			})?.name,
+			it: body.names.find((entry) => {
+				return entry.language.name === "it";
+			})?.name,
+			fr: body.names.find((entry) => {
+				return entry.language.name === "fr";
+			})?.name,
+			ja_hrkt: body.names.find((entry) => {
+				return entry.language.name === "ja-Hrkt";
+			})?.name,
+			zh_hans: body.names.find((entry) => {
+				return entry.language.name === "zh-Hant";
+			})?.name,
+			generation: getPokemonGeneration(body.id),
+			redirect: `${body.species.url.split("/")[6]}?variety=${body.name}`,
+		};
+	});
+
+	// Non-existing entries will reject
+	const allExistingEntries = await Promise.allSettled(
+		pbData.map((entry) => {
+			return pb
+				.collection("pokemon_names")
+				.getFirstListItem(`national_dex=${entry.national_dex}`);
+		})
+	);
+	const existingEntries = allExistingEntries
+		.filter((entry) => {
+			return entry.status === "fulfilled";
+		})
+		.map((entry) => {
+			return entry.value;
+		});
+	console.log(
+		`Extra Pokemon - Found ${existingEntries.length} entries that will be updated`
+	);
+
+	// Find all entries that already exist and need to be updated
+	const updateEntries = pbData.filter((a) => {
+		return existingEntries.some((b) => {
+			return a.national_dex === b.national_dex;
+		});
+	});
+
+	// Find all entries that are new
+	const newEntries = pbData.filter((a) => {
+		return existingEntries.every((b) => {
+			return a.national_dex !== b.national_dex;
+		});
+	});
+
+	console.log(
+		`Extra Pokemon - Found ${newEntries.length} new entries that will be created`
+	);
+
+	// Update all existing entries
+	const updatedResults = await Promise.allSettled(
+		updateEntries.map((entry) => {
+			const existingEntry = existingEntries.find((a) => {
+				return a.national_dex === entry.national_dex;
+			});
+			return pb.collection("pokemon_names").update(existingEntry.id, entry);
+		})
+	).catch((err) => {
+		console.error(
+			`Extra Pokemon - Error when trying to update existing entries: ${err}`
+		);
+	});
+
+	let successfulUpdates = 0;
+	let failedUpdates = 0;
+	const failedErrorMessages = [];
+	updatedResults.forEach((entry) => {
+		if (entry.status === "fulfilled") {
+			successfulUpdates++;
+		} else {
+			failedUpdates++;
+			failedErrorMessages.push(entry);
+		}
+	});
+
+	if (failedUpdates === 0) {
+		console.log(`Extra Pokemon - No errors when updating existing entries`);
+	} else {
+		console.error(
+			`Extra Pokemon - ${failedUpdates} entries have failed to update. Error messages:`
+		);
+		console.error(JSON.stringify(failedErrorMessages));
+	}
+
+	// Create all existing entries
+	const createdResults = await Promise.allSettled(
+		newEntries.map((entry) => {
+			return pb.collection("pokemon_names").create(entry);
+		})
+	);
+
+	let successfulCreations = 0;
+	let failedCreations = 0;
+	const failedCreationErrorMessages = [];
+	createdResults.forEach((entry) => {
+		if (entry.status === "fulfilled") {
+			successfulCreations++;
+		} else {
+			failedCreations++;
+			failedCreationErrorMessages.push(entry);
+		}
+	});
+
+	if (failedCreations === 0) {
+		console.log(`Extra Pokemon - No errors when creating new entries`);
+	} else {
+		console.error(
+			`Extra Pokemon - ${failedCreations} entries have not been created. Error messages:`
+		);
+		console.error(JSON.stringify(failedCreationErrorMessages));
+	}
+}
+
 async function processMove(pb, ids) {
+	if (ids.length === 0) {
+		console.log("Skipping Moves");
+		return;
+	}
 	console.log(`Processing Moves - ${JSON.stringify(ids)}`);
 	const moveApiResponses = await Promise.all(
 		ids.map((id) => {
@@ -345,7 +538,9 @@ async function processMove(pb, ids) {
 }
 
 const getPokemonGeneration = (id) => {
-	if (id <= 151) {
+	if (id > 10000) {
+		return -1;
+	} else if (id <= 151) {
 		return 1;
 	} else if (id > 151 && id <= 252) {
 		return 2;
@@ -368,41 +563,35 @@ const getPokemonGeneration = (id) => {
 
 // handler({
 // 	Records: [
+// 		// {
+// 		// 	messageId: "e4e03a6a-5800-48bf-813b-6a28f0edf85f",
+// 		// 	receiptHandle:
+// 		// 		"AQEByYDXI78U5Iz7vQDs0ucr1IaB0yVly0XmOuqnYI9ph7vCAm1eFD/SJCVvHQTK3zPr3boesYOUwD3H+ZRMDcHNkJFYb2BHK4vxY1f5fFlBT3NKWy2ZzDBGEAyFx+oIXpKXTln1/90xLOZa8k3akXUcOSz19T1bCyXr11fWcEdj3C2jyOdOKFK2Z8SmKLa42eSDD0cz0eIqG00gON49xUc2jTV6Ziujs95f2XS3F4AmNUh2dtJLN/J6dDIGerwq6iRy16+OD5Gqg6bczynaaXT+Yh8TVTPiJPAgRTUbXe6wtBU0ebgZ70ugc5Juwt/qV5vWBymGQkjsdOtuHCcCyhdT96bCtu40/TEbfSCKrMyDoJZwTLiqQGrlJu5rFTKzEC1Y2m0Opp6fNsqxCfIdw3b9lqiSA2W1D38dH6D8AxbPSdk=",
+// 		// 	body: '{"pokemonEntry":1}',
+// 		// 	attributes: {
+// 		// 		ApproximateReceiveCount: "1",
+// 		// 		SentTimestamp: "1704032911576",
+// 		// 		SenderId: "250472156906",
+// 		// 		ApproximateFirstReceiveTimestamp: "1704033006119",
+// 		// 	},
+// 		// 	messageAttributes: {},
+// 		// 	md5OfBody: "d4ae1e457e67bf81562f12d5f2ea2f50",
+// 		// 	eventSource: "aws:sqs",
+// 		// 	eventSourceARN:
+// 		// 		"arn:aws:sqs:eu-west-2:250472156906:pokecompanion-pocketbase",
+// 		// 	awsRegion: "eu-west-2",
+// 		// },
 // 		{
-// 			messageId: "e4e03a6a-5800-48bf-813b-6a28f0edf85f",
-// 			receiptHandle:
-// 				"AQEByYDXI78U5Iz7vQDs0ucr1IaB0yVly0XmOuqnYI9ph7vCAm1eFD/SJCVvHQTK3zPr3boesYOUwD3H+ZRMDcHNkJFYb2BHK4vxY1f5fFlBT3NKWy2ZzDBGEAyFx+oIXpKXTln1/90xLOZa8k3akXUcOSz19T1bCyXr11fWcEdj3C2jyOdOKFK2Z8SmKLa42eSDD0cz0eIqG00gON49xUc2jTV6Ziujs95f2XS3F4AmNUh2dtJLN/J6dDIGerwq6iRy16+OD5Gqg6bczynaaXT+Yh8TVTPiJPAgRTUbXe6wtBU0ebgZ70ugc5Juwt/qV5vWBymGQkjsdOtuHCcCyhdT96bCtu40/TEbfSCKrMyDoJZwTLiqQGrlJu5rFTKzEC1Y2m0Opp6fNsqxCfIdw3b9lqiSA2W1D38dH6D8AxbPSdk=",
-// 			body: '{"pokemonEntry":85}',
-// 			attributes: {
-// 				ApproximateReceiveCount: "1",
-// 				SentTimestamp: "1704032911576",
-// 				SenderId: "250472156906",
-// 				ApproximateFirstReceiveTimestamp: "1704033006119",
-// 			},
-// 			messageAttributes: {},
-// 			md5OfBody: "d4ae1e457e67bf81562f12d5f2ea2f50",
-// 			eventSource: "aws:sqs",
-// 			eventSourceARN:
-// 				"arn:aws:sqs:eu-west-2:250472156906:pokecompanion-pocketbase",
-// 			awsRegion: "eu-west-2",
+// 			body: '{"pokemonExtra":10001}',
 // 		},
 // 		{
-// 			messageId: "2dc6b36c-e3bf-4c20-85bb-6712cd5214a4",
-// 			receiptHandle:
-// 				"AQEBQzFTP6LlfZKA8GA4sD3SbAGHTZ+lS45uFZ0s00oq6lDhiGfM3HS2Xv/P0Bpd7rCcTJC/8QMqFwWbOxEQXQcwN9hFajZl831BRIpBCkTxS+e6pcIoq5XU95X+VHSUvdoZXbLqnRp7edzpxntPWizkzty/CZ8wr9d0LhnOlbBwIKqKS4Lvw9ua+tJU9vl+6iaXv+OckcXfLKzPAET2SxsglgBXuVcNUpvhHuKhy1wqGENVb3Depzv/X+3eRjscwze+VgxFZ3npQa5rRllfrUsaw1OFAznQRLofmIPs451oUbMFneUzJkD5x+dgRISScDTHuHVO4ncrIYeXpXT+bxyNe0jXqkmYJssKYE3OKDxOv8yoKSvlD2L8dcZf8M7vzDrugfiaion817PPXL1VKz9oZHYlu7U0+wt/TPVUz9ma18A=",
-// 			body: '{"pokemonEntry":89}',
-// 			attributes: {
-// 				ApproximateReceiveCount: "1",
-// 				SentTimestamp: "1704032911581",
-// 				SenderId: "250472156906",
-// 				ApproximateFirstReceiveTimestamp: "1704033006119",
-// 			},
-// 			messageAttributes: {},
-// 			md5OfBody: "a72e05b7022c3bd439bb6d23ff65ac35",
-// 			eventSource: "aws:sqs",
-// 			eventSourceARN:
-// 				"arn:aws:sqs:eu-west-2:250472156906:pokecompanion-pocketbase",
-// 			awsRegion: "eu-west-2",
+// 			body: '{"pokemonExtra":10002}',
+// 		},
+// 		{
+// 			body: '{"pokemonExtra":10003}',
+// 		},
+// 		{
+// 			body: '{"pokemonExtra":10004}',
 // 		},
 // 	],
 // });


### PR DESCRIPTION
The `/moves` endpoint returns Pokemon that have IDs > 10'000.

They map to the different Pokemon varieties/forms. We can't just filter those out, because that would be assuming that all Pokemon forms/varieties can exclusively learn the exact same moves as their "default".

So this is to add those entries to the database. We want to add those to the pokemon.json files so that we can do a quick local lookup to redirect those.

Because the API is not consistent between forms and varieties, we need to treat these > 10'000 entries differently. So they are being treated as a new kind of entry in the queue.